### PR TITLE
Fix timer races

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -350,7 +350,12 @@ func (t *internalTimer) Tick(now time.Time) {
 		// defer function execution until the lock is released, and
 		defer func() { go t.fn() }()
 	} else {
-		t.c <- now
+		// it's possible to reset the clock without draining the channel. Don't block in
+		// that case.
+		select {
+		case t.c <- now:
+		default:
+		}
 	}
 	t.mock.removeClockTimer((*internalTimer)(t))
 	t.stopped = true

--- a/clock.go
+++ b/clock.go
@@ -325,8 +325,9 @@ func (t *Timer) Reset(d time.Duration) bool {
 	}
 
 	t.mock.mu.Lock()
-	t.next = t.mock.now.Add(d)
 	defer t.mock.mu.Unlock()
+
+	t.next = t.mock.now.Add(d)
 
 	registered := !t.stopped
 	if t.stopped {
@@ -346,6 +347,13 @@ func (t *internalTimer) Tick(now time.Time) {
 	defer gosched()
 
 	t.mock.mu.Lock()
+	defer t.mock.mu.Unlock()
+
+	// Check if we're stopped, we could have been de-registered after taking the lock and before
+	// calling tick.
+	if t.stopped {
+		return
+	}
 	if t.fn != nil {
 		// defer function execution until the lock is released, and
 		defer func() { go t.fn() }()
@@ -357,9 +365,8 @@ func (t *internalTimer) Tick(now time.Time) {
 		default:
 		}
 	}
-	t.mock.removeClockTimer((*internalTimer)(t))
 	t.stopped = true
-	t.mock.mu.Unlock()
+	t.mock.removeClockTimer((*internalTimer)(t))
 }
 
 // Ticker holds a channel that receives "ticks" at regular intervals.
@@ -408,14 +415,22 @@ type internalTicker Ticker
 
 func (t *internalTicker) Next() time.Time { return t.next }
 func (t *internalTicker) Tick(now time.Time) {
+	defer gosched()
+
+	t.mock.mu.Lock()
+	defer t.mock.mu.Unlock()
+
+	// Check if we're stopped, we could have been de-registered after taking the lock and before
+	// calling tick.
+	if t.stopped {
+		return
+	}
+
 	select {
 	case t.c <- now:
 	default:
 	}
-	t.mock.mu.Lock()
 	t.next = now.Add(t.d)
-	t.mock.mu.Unlock()
-	gosched()
 }
 
 // Sleep momentarily so that other goroutines can process.


### PR DESCRIPTION
1. Select with default when writing to the ticker/timer channel. It may not have been drained and tickers/timers are supposed to drop missed ticks.
2. Fix a race between stop/reset and a tick firing that would cause multiple ticks to be delivered.

The second issue is more interesting.  We release the lock before ticking which means the timer could have been reset. This can lead to the following issue:
    
1. Something triggers a timer, calling `Tick`.
2. Concurrently, `Stop` is called. `Stop` returns false because the timer was running and we succeed in stopping the timer.
3. `Tick` takes the lock and triggers the timer anyways.

The fix is to check if we're stopped inside the timer. Maybe we should avoid dropping the lock in the first place but I want to focus on the direct fix for now.